### PR TITLE
Add logic to retry db connection

### DIFF
--- a/nipap/nipap/backend.py
+++ b/nipap/nipap/backend.py
@@ -786,6 +786,12 @@ class Nipap:
                         self._db_install(db_args['database'])
                         continue
                     raise NipapDatabaseMissingExtensionError("hstore extension not found in the database")
+                # retry if database is not ready (docker friendly)
+                if re.search("could not connect to server: Connection refused", unicode(exc)):
+                    self._logger.error("pgsql: %s" % exc)
+                    self._logger.error("Retrying")
+                    time.sleep(1)
+                    continue
 
                 self._logger.error("pgsql: %s" % exc)
                 raise NipapError("Backend unable to connect to database")


### PR DESCRIPTION
When running NIPAP in docker with docker compose, each container has to be more resilient and handle that the database is not yet up and running. This makes nipapd retry once a second.